### PR TITLE
Fix syntax errors in Kbuild that were introduced by unclean patching

### DIFF
--- a/drivers/gpu/msm/adreno_trace.h
+++ b/drivers/gpu/msm/adreno_trace.h
@@ -17,7 +17,7 @@
 #undef TRACE_SYSTEM
 #define TRACE_SYSTEM kgsl
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH /home/lucifer/Android/kernel/OC/LuciferKernel/drivers/gpu/msm/   //Path: change path as per need
+#define TRACE_INCLUDE_PATH .
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE adreno_trace
 

--- a/drivers/gpu/msm/kgsl_trace.h
+++ b/drivers/gpu/msm/kgsl_trace.h
@@ -17,7 +17,7 @@
 #undef TRACE_SYSTEM
 #define TRACE_SYSTEM kgsl
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH /home/lucifer/Android/kernel/OC/LuciferKernel/drivers/gpu/msm/ //Path: change path as per need
+#define TRACE_INCLUDE_PATH .
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE kgsl_trace
 

--- a/drivers/media/platform/msm/camera_v2-legacy/sensor/msm_sensor.h
+++ b/drivers/media/platform/msm/camera_v2-legacy/sensor/msm_sensor.h
@@ -31,8 +31,8 @@
 #include <media/msm_cam_sensor-legacy.h>
 #include <media/v4l2-subdev.h>
 #include <media/v4l2-ioctl.h>
-#include "/home/lucifer/Android/kernel/OC/LuciferKernel/drivers/media/platform/msm/camera_v2-legacy/sensor/io/msm_camera_i2c.h"    //Path: to be changed as per use
-#include "/home/lucifer/Android/kernel/OC/LuciferKernel/drivers/media/platform/msm/camera_v2-legacy/sensor/io/msm_camera_dt_util.h"  //Path: to be changed as per use
+#include "msm_camera_i2c.h"
+#include "msm_camera_dt_util.h"
 #include "msm_sd.h"
 
 #define DEFINE_MSM_MUTEX(mutexname) \

--- a/drivers/platform/msm/ipa/ipa_clients/rndis_ipa_trace.h
+++ b/drivers/platform/msm/ipa/ipa_clients/rndis_ipa_trace.h
@@ -77,5 +77,5 @@ TRACE_EVENT(
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH /home/lucifer/Android/kernel/OC/LuciferKernel/drivers/platform/msm/ipa/ipa_clients/ //Path: to be changed as per use
+#define TRACE_INCLUDE_PATH .
 #include <trace/define_trace.h>

--- a/drivers/platform/msm/ipa/ipa_v2/ipa_trace.h
+++ b/drivers/platform/msm/ipa/ipa_v2/ipa_trace.h
@@ -148,5 +148,5 @@ TRACE_EVENT(
 
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH /home/lucifer/Android/kernel/OC/LuciferKernel/drivers/platform/msm/ipa/ipa_v2  //Path: to be changed as per need
+#define TRACE_INCLUDE_PATH .
 #include <trace/define_trace.h>

--- a/include/trace/events/msm_cam-legacy.h
+++ b/include/trace/events/msm_cam-legacy.h
@@ -17,7 +17,7 @@
 #define _TRACE_MSM_VFE_H
 
 
-#include "/home/lucifer/Android/kernel/OC/LuciferKernel/drivers/media/platform/msm/camera_v2-legacy/isp/msm_isp.h"  //Path: to be changed as per need
+#include "isp/msm_isp.h"  //Path: Nope
 #include <linux/types.h>
 #include <linux/tracepoint.h>
 

--- a/include/uapi/drm/Kbuild
+++ b/include/uapi/drm/Kbuild
@@ -23,4 +23,5 @@ header-y += virtgpu_drm.h
 header-y += armada_drm.h
 header-y += etnaviv_drm.h
 header-y += vgem_drm.h
+header-y += sde_drm.h
 

--- a/include/uapi/linux/Kbuild
+++ b/include/uapi/linux/Kbuild
@@ -1,4 +1,4 @@
-# UAPI Header export list
+
 header-y += android/
 header-y += byteorder/
 header-y += can/
@@ -509,7 +509,7 @@ header-y += xilinx-v4l2-controls.h
 header-y += zorro.h
 header-y += zorro_ids.h
 header-y += userfaultfd.h
-<<<<<<< HEAD
+
 header-y += ipa_qmi_service_v01.h
 header-y += msm_ipa.h
 header-y += rmnet_ipa_fd_ioctl.h
@@ -518,7 +518,7 @@ header-y += msm-core-interface.h
 header-y += msm_rotator.h
 header-y += bgcom_interface.h
 header-y += nfc/
-=======
+
 header-y += auto_dev-ioctl.h
 header-y += bcache.h
 header-y += btrfs_tree.h
@@ -539,4 +539,4 @@ header-y += stm.h
 header-y += wil6210_uapi.h
 header-y += cifs/
 header-y += genwqe/
->>>>>>> d472b7e2f632... install several missing uapi headers
+

--- a/include/uapi/linux/cifs/Kbuild
+++ b/include/uapi/linux/cifs/Kbuild
@@ -1,6 +1,5 @@
-<<<<<<< HEAD
 # UAPI Header export list
 no-export-headers += cifs_mount.h
-=======
+
 header-y += cifs_mount.h
->>>>>>> d472b7e2f632... install several missing uapi headers
+

--- a/include/uapi/linux/genwqe/Kbuild
+++ b/include/uapi/linux/genwqe/Kbuild
@@ -1,6 +1,6 @@
-<<<<<<< HEAD
+
 # UAPI Header export list
 no-export-headers += genwqe_card.h
-=======
+
 header-y += genwqe_card.h
->>>>>>> d472b7e2f632... install several missing uapi headers
+


### PR DESCRIPTION
Title says it all. Make quits because it does not like all the ========== and >>>>>>>>>>>>>>>>>>

Also the commit that sets the include paths right again is in there as well.
I don't know why you did that, but it ruins it for everyone else who doesn't have that path on their system (chances are next to nil) and there's probably a more elegant way to fix header-not-found errors if you were getting them.